### PR TITLE
fix: `badge` background contrast

### DIFF
--- a/themes/One Sandbox-color-theme.json
+++ b/themes/One Sandbox-color-theme.json
@@ -5,7 +5,7 @@
     "activityBar.background": "#161616",
     "activityBar.border": "#27292b",
     "activityBar.activeBorder": "#e6e6e6",
-    "badge.background": "#161616",
+    "badge.background": "#343434",
     "activityBarBadge.background": "#343434",
     "activityBar.foreground": "#d7dae0",
     "button.background": "#27292b",


### PR DESCRIPTION
This pull request includes a small change to the background color of the badge to improve visual consistency.

Feel free to close it if you don't like this change.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="387" alt="Before 2" src="https://github.com/user-attachments/assets/b86bd8c6-fb79-48aa-bab2-b3cba35d860a"></td>
    <td><img width="387" alt="After 2" src="https://github.com/user-attachments/assets/41fb6288-20e9-49da-a684-21c990e47c5b"></td>
  </tr>
  <tr>
    <td><img width="388" alt="Before 3" src="https://github.com/user-attachments/assets/48b51067-68ea-48bd-8f6d-48099d08e3ae"></td>
    <td><img width="387" alt="After 3" src="https://github.com/user-attachments/assets/9a81fca7-118a-4aa3-958b-1e7650f0a311"></td>
  </tr>
  <tr>
    <td><img width="386" alt="Before 1" src="https://github.com/user-attachments/assets/c15e3fff-198c-44ed-b451-5a133206596a"></td>
    <td><img width="386" alt="After 1" src="https://github.com/user-attachments/assets/4ff61c0c-4e27-49c6-9c8e-7f2292630ffd"></td>
  </tr>
</table>